### PR TITLE
Do_while task relevant loop over task calculation fix (#3351)

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/DoWhile.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/DoWhile.java
@@ -185,7 +185,18 @@ public class DoWhile extends WorkflowSystemTask {
                 break;
             }
         }
-        return allTasksTerminal;
+
+        if (!allTasksTerminal) {
+            // Cases where tasks directly inside loop over are not completed.
+            // loopOver -> [task1 -> COMPLETED, task2 -> IN_PROGRESS]
+            return false;
+        }
+
+        // Check all the tasks in referenceNameToModel are completed or not. These are set of tasks
+        // which are not directly inside loopOver tasks, but they are under hierarchy
+        // loopOver -> [decisionTask -> COMPLETED [ task1 -> COMPLETED, task2 -> IN_PROGRESS]]
+        return referenceNameToModel.values().stream()
+                .noneMatch(taskModel -> !taskModel.getStatus().isTerminal());
     }
 
     boolean scheduleNextIteration(

--- a/test-harness/src/test/resources/do_while_with_decision_task.json
+++ b/test-harness/src/test/resources/do_while_with_decision_task.json
@@ -1,0 +1,62 @@
+{
+  "name": "DO_While_with_Decision_task",
+  "description": "Program for testing loop behaviour",
+  "version": 1,
+  "schemaVersion": 2,
+  "ownerEmail": "xyz@company.eu",
+  "tasks": [
+    {
+      "name": "LoopTask",
+      "taskReferenceName": "LoopTask",
+      "type": "DO_WHILE",
+      "inputParameters": {
+        "list": "${workflow.input.list}"
+      },
+      "loopCondition": "$.LoopTask['iteration'] < $.list.length",
+      "loopOver": [
+        {
+          "name": "GetNumberAtIndex",
+          "taskReferenceName": "GetNumberAtIndex",
+          "type": "INLINE",
+          "inputParameters": {
+            "evaluatorType": "javascript",
+            "list": "${workflow.input.list}",
+            "iterator": "${LoopTask.output.iteration}",
+            "expression": "function getElement() { return $.list.get($.iterator - 1); } getElement();"
+          }
+        },
+        {
+          "name": "SwitchTask",
+          "taskReferenceName": "SwitchTask",
+          "type": "SWITCH",
+          "evaluatorType": "javascript",
+          "inputParameters": {
+            "param": "${GetNumberAtIndex.output.result}"
+          },
+          "expression": "$.param > 0",
+          "decisionCases": {
+            "true": [
+              {
+                "name": "WaitTask",
+                "taskReferenceName": "WaitTask",
+                "type": "WAIT",
+                "inputParameters": {
+                }
+              },
+              {
+                "name": "ComputeNumber",
+                "taskReferenceName": "ComputeNumber",
+                "type": "INLINE",
+                "inputParameters": {
+                  "evaluatorType": "javascript",
+                  "number": "${GetNumberAtIndex.output.result.number}",
+                  "expression": "function compute() { return $.number+10; } compute();"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Simplifying the logic to check relevant task for do_while task

The cases where decision/ fork_join, dynamic_fork is part of loop over task then ideally do_while task must wait before all the task gets completed.

* integration tests

* spotless

* proper fix

* spotless

* integration test for remaining scenario.

* removed not necessary test case.

The test case was when decision task is part of loop over task and decision task contains two tasks and only one task is scheduled. But there will not be any case where we schedule only one task given the decision case has two tasks.

* spotless

* spotless 2

* spotless 3

Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_
